### PR TITLE
use soureFile locals to store ts.EntityName instances to help resolve…

### DIFF
--- a/src/metadataGeneration/controllerGenerator.ts
+++ b/src/metadataGeneration/controllerGenerator.ts
@@ -33,7 +33,7 @@ export class ControllerGenerator {
     }
 
     const sourceFile = this.node.parent.getSourceFile();
-
+    
     return {
       location: sourceFile.fileName,
       methods: this.buildMethods(),
@@ -101,7 +101,7 @@ export class ControllerGenerator {
     // this will allow the TypeResolver to correctly find, for example, that a generic
     // type parameter `T` defined on a nested base class method resolves to some model `Foo`, 
     // because at the top of the inheritance chain the concrete class used `Foo` as `T`
-    const genericTypeMap: Tsoa.GenericTypeMap = new Map<string, Map<string, string>>();
+    const genericTypeMap: Tsoa.GenericTypeMap = new Map<string, Map<string, string | ts.EntityName>>();
     
     const baseTypes = typeNode.getBaseTypes();
 
@@ -114,7 +114,7 @@ export class ControllerGenerator {
 
           // ensure a top level map entry for this base type
           if (!genericTypeMap.has(baseTypeName)) {
-            genericTypeMap.set(baseTypeName, new Map<string, string>());
+            genericTypeMap.set(baseTypeName, new Map<string, string | ts.EntityName>());
           }
 
           const baseTypeMap = genericTypeMap.get(baseTypeName);
@@ -125,7 +125,21 @@ export class ControllerGenerator {
               if (target.typeParameters) {
                 const targetParam = target.typeParameters[index] as ts.TypeReference;
                 const targetParamName = targetParam.symbol ? targetParam.symbol.name : ts.TypeFlags[targetParam.flags];
-                const baseArgName = baseArg.symbol ? baseArg.symbol.name : ts.TypeFlags[baseArg.flags];
+                let baseArgName: string | ts.EntityName = baseArg.symbol ? baseArg.symbol.name : ts.TypeFlags[baseArg.flags];
+                
+                // use the source file locals to attempt pushing a ts.EntityName into the map, which
+                // will allow the type resolver to properly resolve the model even in inherited controllers
+                // (casting to any because for some reason the ts type does not include the `locals` map,
+                // which definitely exists at run time)
+                const sourceFile = this.node.parent.getSourceFile() as any
+                if (sourceFile.locals) {
+                  const locals = sourceFile.locals as Map<string, ts.Symbol>;
+                  const local = locals.get(baseArgName);
+
+                  if (local && local.declarations.length) {
+                    baseArgName = (local.declarations[0] as ts.NamedDeclaration).name as ts.Identifier || baseArgName;
+                  }
+                }
                 
                 baseTypeMap.set(targetParamName, baseArgName);
               }
@@ -135,7 +149,7 @@ export class ControllerGenerator {
             const baseGenericMap = this.getResolvedGenericTypeMap(target);
             baseGenericMap.forEach((value, key) => {
               if (!genericTypeMap.has(key)) {
-                genericTypeMap.set(key, new Map<string, string>());
+                genericTypeMap.set(key, new Map<string, string | ts.EntityName>());
               }
 
               const nestedBaseTypeMap = genericTypeMap.get(key);

--- a/src/metadataGeneration/tsoa.ts
+++ b/src/metadataGeneration/tsoa.ts
@@ -1,3 +1,5 @@
+import * as ts from 'typescript';
+
 export namespace Tsoa {
   export interface Metadata {
     controllers: Controller[];
@@ -102,5 +104,5 @@ export namespace Tsoa {
     [refName: string]: Tsoa.ReferenceType;
   }
 
-  export type GenericTypeMap = Map<string, Map<string, string>>
+  export type GenericTypeMap = Map<string, Map<string, string | ts.EntityName>>
 }

--- a/src/metadataGeneration/typeResolver.ts
+++ b/src/metadataGeneration/typeResolver.ts
@@ -109,8 +109,8 @@ export class TypeResolver {
     const literalType = this.getLiteralType(typeReference.typeName);
     if (literalType) { return literalType; }
 
-    const primitiveFromGenericTypeName = this.resolvePrimitiveTypeFromMap(this.resolveFqTypeName(typeReference.typeName))
-    if (primitiveFromGenericTypeName) return primitiveFromGenericTypeName
+    const primitiveFromGenericTypeName = this.resolvePrimitiveTypeFromMap(this.resolveFqTypeName(typeReference.typeName));
+    if (primitiveFromGenericTypeName) return primitiveFromGenericTypeName;
 
     let referenceType: Tsoa.ReferenceType;
     if (typeReference.typeArguments && typeReference.typeArguments.length === 1) {
@@ -279,7 +279,7 @@ export class TypeResolver {
       const resolvedTypeName = this.resolveGenericTypeNameFromMap(typeName);
       let modelTypeName = resolvedTypeName && typeof resolvedTypeName !== 'string'
         ? resolvedTypeName as ts.EntityName
-        : type
+        : type;
 
       const modelType = this.getModelTypeDeclaration(modelTypeName);
       const properties = this.getModelProperties(modelType, genericTypes);
@@ -359,7 +359,7 @@ export class TypeResolver {
 
     const typeNameString = typeof resolvedTypeName === 'string'
       ? resolvedTypeName
-      : (resolvedTypeName as ts.EntityName).getText()
+      : (resolvedTypeName as ts.EntityName).getText();
 
     return localReferenceTypeCache[typeNameString];
   }
@@ -380,7 +380,7 @@ export class TypeResolver {
 
       return typeof resolvedTypeName === 'string'
         ? resolvedTypeName
-        : (resolvedTypeName as ts.EntityName).getText()
+        : (resolvedTypeName as ts.EntityName).getText();
     }
 
     return typeName + genericTypes.map((t) => this.getAnyTypeName(t)).join('');

--- a/tests/fixtures/controllers/baseController.ts
+++ b/tests/fixtures/controllers/baseController.ts
@@ -1,38 +1,31 @@
-import {
-  Controller,
-  Get,
-  Patch,
-  Post,
-  Put,
-} from '../../../src';
-import { ModelService } from '../services/modelService';
-import { TestModel } from '../testModel';
+import { Controller, Get, Patch, Post, Put } from '../../../src'
+import { ModelService } from '../services/modelService'
 
-class SuperBaseController extends Controller {
+class SuperBaseController<T> extends Controller {
   @Patch('SuperBasePatch')
-  public async superBasePatch(): Promise<TestModel> {
-    return new ModelService().getModel();
+  public async superBasePatch(): Promise<T> {
+    return (new ModelService().getModel() as unknown) as T
   }
 }
 
-export class BaseController extends SuperBaseController{
+export class BaseController<T> extends SuperBaseController<T> {
   @Get('Get')
-  public async getMethod(): Promise<TestModel> {
-    return new ModelService().getModel();
+  public async getMethod(): Promise<T> {
+    return (new ModelService().getModel() as unknown) as T
   }
 
   @Post('Post')
-  public async postMethod(): Promise<TestModel> {
-    return new ModelService().getModel();
+  public async postMethod(): Promise<T> {
+    return (new ModelService().getModel() as unknown) as T
   }
 
   @Get('Base')
-  public async baseMethod(): Promise<TestModel> {
-    return new ModelService().getModel();
+  public async baseMethod(): Promise<T> {
+    return (new ModelService().getModel() as unknown) as T
   }
 
   @Put('OverwrittenMethod')
-  public async putMethod(): Promise<TestModel> {
-    return new ModelService().getModel();
+  public async putMethod(): Promise<T> {
+    return (new ModelService().getModel() as unknown) as T
   }
 }

--- a/tests/fixtures/controllers/duplicateMethodController.ts
+++ b/tests/fixtures/controllers/duplicateMethodController.ts
@@ -9,7 +9,7 @@ import { TestModel } from '../testModel';
 import { BaseController } from './baseController';
 
 @Route('DuplicateMethodTest')
-export class DuplicateMethodController extends BaseController {
+export class DuplicateMethodController extends BaseController<TestModel> {
   @Get('Get')
   public async getMethod(): Promise<TestModel> {
       return new ModelService().getModel();

--- a/tests/fixtures/controllers/emptySuperClassGenericController.ts
+++ b/tests/fixtures/controllers/emptySuperClassGenericController.ts
@@ -1,0 +1,10 @@
+import { Route } from '../../../src'
+import { TestModel } from '../testModel'
+import { BaseController } from './baseController'
+
+class SuperBase<T> extends BaseController<T> {
+}
+
+@Route('EmptySuperClassGenericController')
+export class EmptySuperClassGenericController extends SuperBase<TestModel> {
+}

--- a/tests/fixtures/controllers/inheritanceMethodController.ts
+++ b/tests/fixtures/controllers/inheritanceMethodController.ts
@@ -1,17 +1,13 @@
-import {
-  Get,
-  Patch,
-  Route,
-} from '../../../src';
-import { ModelService } from '../services/modelService';
-import { TestModel } from '../testModel';
-import { BaseController } from './baseController';
+import { Get, Patch, Route } from '../../../src'
+import { ModelService } from '../services/modelService'
+import { TestModel } from '../testModel'
+import { BaseController } from './baseController'
 
 @Route('InheritedMethodTest')
-export class InheritanceMethodController extends BaseController {
+export class InheritanceMethodController extends BaseController<TestModel> {
   @Get('Get')
   public async getMethod(): Promise<TestModel> {
-      return new ModelService().getModel();
+    return new ModelService().getModel();
   }
 
   @Patch('Patch')

--- a/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
+++ b/tests/unit/swagger/definitionsGeneration/metadata.spec.ts
@@ -15,12 +15,14 @@ describe('Metadata generation', () => {
   });
 
   describe('InheritedMethodGenerator', () => {
-    const parameterMetadata = new MetadataGenerator('./tests/fixtures/controllers/inheritanceMethodController.ts').Generate();
+    const inheritanceMetadata = new MetadataGenerator('./tests/fixtures/controllers/inheritanceMethodController.ts').Generate();
+    const emptySuperMetadata = new MetadataGenerator('./tests/fixtures/controllers/emptySuperClassGenericController.ts').Generate();
     const duplicateGenerator = new MetadataGenerator('./tests/fixtures/controllers/duplicateMethodController.ts');
-    const controller = parameterMetadata.controllers[0];
+    const inheritanceController = inheritanceMetadata.controllers[0];
+    const emptySuperController = emptySuperMetadata.controllers[0];
 
     it('should inherit postMethod from BaseController', () => {
-      const method = controller.methods.find(m => m.name === 'postMethod');
+      const method = inheritanceController.methods.find(m => m.name === 'postMethod');
 
       if (!method) {
         throw new Error('Method postMethod not defined!');
@@ -29,10 +31,11 @@ describe('Metadata generation', () => {
       expect(method.method).to.equal('post');
       expect(method.path).to.equal('Post');
       expect(method.name).to.equal('postMethod');
+      expect((method.type as Tsoa.ReferenceType).refName).to.equal('TestModel');
     });
 
     it('should inherit superBasePatch from SuperBaseController', () => {
-      const method = controller.methods.find(m => m.name === 'superBasePatch');
+      const method = inheritanceController.methods.find(m => m.name === 'superBasePatch');
 
       if (!method) {
         throw new Error('Method superBasePatch not defined!');
@@ -41,6 +44,33 @@ describe('Metadata generation', () => {
       expect(method.method).to.equal('patch');
       expect(method.path).to.equal('SuperBasePatch');
       expect(method.name).to.equal('superBasePatch');
+      expect((method.type as Tsoa.ReferenceType).refName).to.equal('TestModel');
+    });
+
+    it('should inherit postMethod from BaseController when super class file is a stub', () => {
+      const method = emptySuperController.methods.find(m => m.name === 'postMethod');
+
+      if (!method) {
+        throw new Error('Method postMethod not defined!');
+      }
+
+      expect(method.method).to.equal('post');
+      expect(method.path).to.equal('Post');
+      expect(method.name).to.equal('postMethod');
+      expect((method.type as Tsoa.ReferenceType).refName).to.equal('TestModel');
+    });
+
+    it('should inherit superBasePatch from SuperBaseController when super class file is a stub', () => {
+      const method = emptySuperController.methods.find(m => m.name === 'superBasePatch');
+
+      if (!method) {
+        throw new Error('Method superBasePatch not defined!');
+      }
+
+      expect(method.method).to.equal('patch');
+      expect(method.path).to.equal('SuperBasePatch');
+      expect(method.name).to.equal('superBasePatch');
+      expect((method.type as Tsoa.ReferenceType).refName).to.equal('TestModel');
     });
 
     it('should error if a duplicate method is found', () => {


### PR DESCRIPTION
resolves issue related to resolving generic type template variables in a base class where the model is imported at the super-class file level and not base class, and where the super-class is a stub. 